### PR TITLE
fix: workaround broken `asyncio.staggered` on python < 3.8.2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -43,7 +43,7 @@ jobs:
           - "3.11"
           - "3.12"
         os:
-          - ubuntu-latest
+          - ubuntu-20.04
           - windows-latest
           - macOS-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8.1"
+          - "3.8.0"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.8.1"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -46,6 +46,9 @@ jobs:
           - ubuntu-20.04
           - windows-latest
           - macOS-latest
+        exclude:
+          - os: macOS-latest
+            python-version: "3.8.0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -5,10 +5,22 @@ import collections
 import functools
 import itertools
 import socket
+import sys
 from asyncio import staggered
 from typing import List, Optional, Sequence
 
 from .types import AddrInfoType
+
+if sys.version_info < (3, 8, 2):  # noqa: UP036
+    # asyncio.staggered is broken in Python 3.8.0 and 3.8.1
+    # so it must be patched:
+    # https://github.com/aio-libs/aiohttp/issues/8556
+    # https://bugs.python.org/issue39129
+    # https://github.com/python/cpython/pull/17693
+    import asyncio
+    import asyncio.futures
+
+    asyncio.futures.TimeoutError = asyncio.TimeoutError  # type: ignore[attr-defined]
 
 
 async def start_connection(


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

Patch missing `asyncio.futures.TimeoutError` with Python < 3.8.2

## Are there changes in behavior for the user?

Library will no longer fail on Python 3.8.0 and Python 3.8.1

## Related issue number

fixes https://github.com/aio-libs/aiohttp/issues/8556
