### PR TITLE
chore: fix permissions in release CI workflow

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -114,6 +114,12 @@ jobs:
     outputs:
       released: ${{ steps.release.outputs.released }}
 
+    environment: pypi
+    concurrency: release
+    permissions:
+      id-token: write
+      contents: write
+
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -114,7 +114,6 @@ jobs:
     outputs:
       released: ${{ steps.release.outputs.released }}
 
-    environment: pypi
     concurrency: release
     permissions:
       id-token: write


### PR DESCRIPTION
This is the first release since the permissions were reworked. The release failed because the `build_release` pushes to `main` https://github.com/aio-libs/aiohappyeyeballs/actions/runs/10184595236