### PR TITLE
fix: add missing python version classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,11 @@ classifiers = [
     "Natural Language :: English",
     "Operating System :: OS Independent",
     "Topic :: Software Development :: Libraries",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "License :: OSI Approved :: Python Software Foundation License"
 ]
 packages = [


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Add missing python version classifiers

## Are there changes in behavior for the user?

none
