### PR TITLE
fix: resolve conflicting license identifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ name = "aiohappyeyeballs"
 version = "2.3.4"
 description = "Happy Eyeballs for asyncio"
 authors = ["J. Nick Koston <nick@koston.org>"]
-license = "PSF-2.0"
 readme = "README.md"
 repository = "https://github.com/aio-libs/aiohappyeyeballs"
 documentation = "https://aiohappyeyeballs.readthedocs.io"


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

pypi saw `PSF-2.0` as `Other/Proprietary License` and the classifier as `Python Software Foundation License`. Since we only need one, remove `PSF-2.0` to resolve the conflict

This is a followup fix for #59