### PR TITLE
chore: remove redundant asyncio import

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -17,7 +17,6 @@ if sys.version_info < (3, 8, 2):  # noqa: UP036
     # https://github.com/aio-libs/aiohttp/issues/8556
     # https://bugs.python.org/issue39129
     # https://github.com/python/cpython/pull/17693
-    import asyncio
     import asyncio.futures
 
     asyncio.futures.TimeoutError = asyncio.TimeoutError  # type: ignore[attr-defined]

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1,5 +1,6 @@
 import asyncio
 import socket
+import sys
 from types import ModuleType
 from typing import Tuple
 from unittest import mock
@@ -1272,3 +1273,10 @@ async def test_all_same_exception(
         ("dead:aaaa::", 80, 0, 0),
         ("107.6.106.83", 80),
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.skipif(sys.version_info >= (3, 8, 2), reason="requires < python 3.8.2")
+def test_python_38_compat() -> None:
+    """Verify python < 3.8.2 compatibility."""
+    assert asyncio.futures.TimeoutError is asyncio.TimeoutError  # type: ignore[attr-defined]


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

remove redundant asyncio import

## Are there changes in behavior for the user?

no

## Related issue number

https://github.com/aio-libs/aiohappyeyeballs/pull/61#discussion_r1699031241