### PR TITLE
fix: preserve errno if all exceptions have the same errno

### DIFF
--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1191,9 +1191,10 @@ async def test_ipv64_laddr_bind_fails_all_eyeballs_interleave_first__ipv6_fails(
 
 @patch_socket
 @pytest.mark.asyncio
-async def test_all_same_exception(
+async def test_all_same_exception_and_same_errno(
     m_socket: ModuleType,
 ) -> None:
+    """Test that all exceptions are the same and have the same errno."""
     mock_socket = mock.MagicMock(
         family=socket.AF_INET,
         type=socket.SOCK_STREAM,
@@ -1256,7 +1257,7 @@ async def test_all_same_exception(
     # We should get the same exception raised if they are all the same
     with mock.patch.object(loop, "sock_connect", _sock_connect), pytest.raises(
         OSError, match="all fail"
-    ):
+    ) as exc_info:
         assert (
             await start_connection(
                 addr_info,
@@ -1266,6 +1267,98 @@ async def test_all_same_exception(
             )
             == mock_socket
         )
+
+    assert exc_info.value.errno == 5
+
+    # All calls failed
+    assert create_calls == [
+        ("dead:beef::", 80, 0, 0),
+        ("dead:aaaa::", 80, 0, 0),
+        ("107.6.106.83", 80),
+    ]
+
+
+@patch_socket
+@pytest.mark.asyncio
+async def test_all_same_exception_and_with_different_errno(
+    m_socket: ModuleType,
+) -> None:
+    """Test no errno is set if all OSError have different errno."""
+    mock_socket = mock.MagicMock(
+        family=socket.AF_INET,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+        fileno=mock.MagicMock(return_value=1),
+    )
+    create_calls = []
+
+    def _socket(*args, **kw):
+        for attr in kw:
+            setattr(mock_socket, attr, kw[attr])
+        return mock_socket
+
+    async def _sock_connect(
+        sock: socket.socket, address: Tuple[str, int, int, int]
+    ) -> None:
+        create_calls.append(address)
+        raise OSError(len(create_calls), "all fail")
+
+    m_socket.socket = _socket  # type: ignore
+    ipv6_addr_info = (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("dead:beef::", 80, 0, 0),
+    )
+    ipv6_addr_info_2 = (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("dead:aaaa::", 80, 0, 0),
+    )
+    ipv4_addr_info = (
+        socket.AF_INET,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("107.6.106.83", 80),
+    )
+    addr_info = [ipv6_addr_info, ipv6_addr_info_2, ipv4_addr_info]
+    local_addr_infos = [
+        (
+            socket.AF_INET6,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("::1", 0, 0, 0),
+        ),
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("127.0.0.1", 0),
+        ),
+    ]
+    loop = asyncio.get_running_loop()
+    # We should get the same exception raised if they are all the same
+    with mock.patch.object(loop, "sock_connect", _sock_connect), pytest.raises(
+        OSError, match="all fail"
+    ) as exc_info:
+        assert (
+            await start_connection(
+                addr_info,
+                happy_eyeballs_delay=0.3,
+                interleave=2,
+                local_addr_infos=local_addr_infos,
+            )
+            == mock_socket
+        )
+
+    # No errno is set if they are all different
+    assert exc_info.value.errno is None
 
     # All calls failed
     assert create_calls == [


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Preserve errno if all exceptions have the same errno

## Are there changes in behavior for the user?

solves a regression in aiohttp

## Related issue number

fixes #76
