### PR TITLE
fix: adjust license classifier to better reflect license terms

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aiohappyeyeballs"
 version = "2.3.4"
 description = "Happy Eyeballs for asyncio"
 authors = ["J. Nick Koston <nick@koston.org>"]
-license = "PSF-2.0"
+license = "Python-2.0"
 readme = "README.md"
 repository = "https://github.com/aio-libs/aiohappyeyeballs"
 documentation = "https://aiohappyeyeballs.readthedocs.io"
@@ -18,7 +18,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: Python Software Foundation License"
+    "License :: OSI Approved :: Python License (CNRI Python License)"
 ]
 packages = [
     { include = "aiohappyeyeballs", from = "src" },


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

The intent is to license the code under the same terms as python itself as the code is derived from cpython


## Are there changes in behavior for the user?

no

## Related issue number
fixes #59 (again)
