### PR TITLE
fix: adjust license to Python-2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "aiohappyeyeballs"
 version = "2.3.5"
 description = "Happy Eyeballs for asyncio"
 authors = ["J. Nick Koston <nick@koston.org>"]
-license = "Python-2.0"
+license = "Python-2.0.1"
 readme = "README.md"
 repository = "https://github.com/aio-libs/aiohappyeyeballs"
 documentation = "https://aiohappyeyeballs.readthedocs.io"
@@ -17,8 +17,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12",
-    "License :: OSI Approved :: Python License (CNRI Python License)"
+    "Programming Language :: Python :: 3.12"
 ]
 packages = [
     { include = "aiohappyeyeballs", from = "src" },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The license is intended to be the same as cpython itself https://spdx.org/licenses/Python-2.0.1.html

Unfortunately as there currently is no exact matching classifier, remove the classifier: https://pypi.org/classifiers/

## Are there changes in behavior for the user?

no

## Related issue number
closes #79
closes #81