### PR TITLE
fix: correct classifier for license Python-2.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: 3.12"
+    "Programming Language :: Python :: 3.12",
+    "License :: OSI Approved :: Python Software Foundation License"
 ]
 packages = [
     { include = "aiohappyeyeballs", from = "src" },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Correct classifier for license Python-2.0.1 according to available classifiers listed at https://pypi.org/classifiers/

Without this patch, pip-licenses disrupted CI license check with below error which was not raised at version prior 2.3.5.

```license Other/Proprietary License not in allow-only licenses was found for package aiohappyeyeballs:2.3.6```

It seems that the change was made by [this commit](https://github.com/aio-libs/aiohappyeyeballs/commit/30a2dc57c49d1000ebdafa8c81ecf4f79e35c9f3), which correctly removed `CNRI Python License` part but unfortunately didn't update properly which is this PR for.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?
There is no change in functionalities except license checking above.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
