### PR TITLE
docs: fix a trivial typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ already have a list of addrinfo and not a DNS name.
 The stdlib version of `loop.create_connection()`
 will only work when you pass in an unresolved name which
 is not a good fit when using DNS caching or resolving
-names via another method such was `zeroconf`.
+names via another method such as `zeroconf`.
 
 ## Installation
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Fix a trivial typo in `README.md` – `such was` in place of `such as`.
<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

<!-- Outline any notable behaviour for the end users. -->
No.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->
N/A, no issue opened.

## Checklist

- [x] I think the code is well written
- [X] Unit tests for the changes exist **N/A, no code changes.**
- [x] Documentation reflects the changes **N/A, nothing to docuemnt.**
