### PR TITLE
chore: update readme to include license information

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Install this via pip (or your favourite package manager):
 
 ## License
 
-aiohappyeyeballs is licensed under the same terms a cpython itself.
+[aiohappyeyeballs is licensed under the same terms a cpython itself.](https://github.com/python/cpython/blob/main/LICENSE)
 
 ## Example usage
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ Install this via pip (or your favourite package manager):
 
 `pip install aiohappyeyeballs`
 
+## License
+
+aiohappyeyeballs is licensed under the same terms a cpython itself.
+
 ## Example usage
 
 ```python


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Update readme to include license information, as we seem to get a new issue from people using license scanners that are unaware of the python license each week

"aiohappyeyeballs is licensed under the same terms a cpython itself."
