### PR TITLE
fix: avoid passing loop to staggered.staggered_race

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -93,7 +93,6 @@ async def start_connection(
                 for addrinfo in addr_infos
             ),
             happy_eyeballs_delay,
-            loop=current_loop,
         )
 
     if sock is None:


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

remove loop param from call to `staggered.staggered_race`

ref https://github.com/aio-libs/aiohttp/issues/8599#issuecomment-2378018509
ref https://github.com/python/cpython/issues/124309
ref https://github.com/python/cpython/issues/124639
ref https://github.com/python/cpython/pull/124390
ref https://github.com/python/cpython/pull/124574
ref https://github.com/python/cpython/pull/124573


## Are there changes in behavior for the user?
no