### PR TITLE
Support Python 3.8+ in backported asyncio.staggered

### DIFF
--- a/src/aiohappyeyeballs/_staggered.py
+++ b/src/aiohappyeyeballs/_staggered.py
@@ -67,8 +67,8 @@ async def staggered_race(
     # TODO: when we have aiter() and anext(), allow async iterables in coro_fns.
     loop = loop or events.get_running_loop()
     enum_coro_fns = enumerate(coro_fns)
-    winner_result = None
-    winner_index = None
+    winner_result: Optional[_T] = None
+    winner_index: Optional[int] = None
     exceptions: List[Optional[BaseException]] = []
     running_tasks: List[tasks.Task[None]] = []
 


### PR DESCRIPTION
## What do these changes do?

Even though backported `staggered.py` for Python 3.12+ is used only in Python3.12, this module cannot be imported in Python 3.8. I backported an older version of `staggered.py` that is compatible with Python 3.8, but does not support eager task factories. I preserved type annotations and added missing ones.

I think, since `aiohappyeyeballs` is a py38+ project, all modules should be at least importable in py38+ for linting and type checking. Also, `staggered_race` function signature should now be the same for py312 and for lower python versions.

Backported from https://github.com/python/cpython/blob/16b46ebd2b0025aa461fdfc95fbf98a4f04b49e6/Lib/asyncio/staggered.py, added missing type annotations.

## Are there changes in behavior for the user?

No

## Related issue number

No related issue number

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
