### PR TITLE
fix: handle OSError on failure to close socket instead of raising IndexError

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -178,7 +178,7 @@ async def _connect_sock(
         if sock is not None:
             try:
                 sock.close()
-            except BaseException as e:
+            except OSError as e:
                 my_exceptions.append(e)
                 raise
         raise
@@ -186,7 +186,7 @@ async def _connect_sock(
         if sock is not None:
             try:
                 sock.close()
-            except BaseException as e:
+            except OSError as e:
                 my_exceptions.append(e)
                 raise
         raise

--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -176,11 +176,19 @@ async def _connect_sock(
     except (RuntimeError, OSError) as exc:
         my_exceptions.append(exc)
         if sock is not None:
-            sock.close()
+            try:
+                sock.close()
+            except BaseException as e:
+                my_exceptions.append(e)
+                raise
         raise
     except:
         if sock is not None:
-            sock.close()
+            try:
+                sock.close()
+            except BaseException as e:
+                my_exceptions.append(e)
+                raise
         raise
     finally:
         exceptions = my_exceptions = None  # type: ignore[assignment]

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1825,3 +1825,35 @@ async def test_cancellation_is_not_swallowed(
 def test_python_38_compat() -> None:
     """Verify python < 3.8.2 compatibility."""
     assert asyncio.futures.TimeoutError is asyncio.TimeoutError  # type: ignore[attr-defined]
+
+
+@pytest.mark.asyncio
+@patch_socket
+async def test_single_addr_info_close_errors(m_socket: ModuleType) -> None:
+    mock_socket = mock.MagicMock(
+        family=socket.AF_INET,
+        type=socket.SOCK_STREAM,
+        proto=socket.IPPROTO_TCP,
+        fileno=mock.MagicMock(return_value=1),
+    )
+    mock_socket.configure_mock(**{
+        'connect.side_effect': asyncio.CancelledError('during connect'),
+        'close.side_effect': OSError('during close')
+    })
+
+    def _socket(*args, **kw):
+        return mock_socket
+
+    m_socket.socket = _socket  # type: ignore
+
+    addr_info = [
+        (
+            socket.AF_INET,
+            socket.SOCK_STREAM,
+            socket.IPPROTO_TCP,
+            "",
+            ("107.6.106.82", 80),
+        )
+    ]
+    with pytest.raises(OSError):
+        await start_connection(addr_info)

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -1836,10 +1836,12 @@ async def test_single_addr_info_close_errors(m_socket: ModuleType) -> None:
         proto=socket.IPPROTO_TCP,
         fileno=mock.MagicMock(return_value=1),
     )
-    mock_socket.configure_mock(**{
-        'connect.side_effect': asyncio.CancelledError('during connect'),
-        'close.side_effect': OSError('during close')
-    })
+    mock_socket.configure_mock(
+        **{
+            "connect.side_effect": asyncio.CancelledError("during connect"),
+            "close.side_effect": OSError("during close"),
+        }
+    )
 
     def _socket(*args, **kw):
         return mock_socket


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

It is possible for `loop.sock_connect` to fail in such a way that the wrapped socket no longer refers to a valid file descriptor. In this, the exception handler can fail on the attempt to call `sock.close()`. When this happens, `start_connection` can have `sock == None` and `exceptions == []`. This causes an `IndexError` because it assumes that `exceptions` always contains at least one exception instance.

## Are there changes in behavior for the user?

I experienced crashes when handling connections with short timeouts.

## Related issue number

## Checklist

- [x] I think the code is well written
- [ ] Unit tests for the changes exist
- [ ] Documentation reflects the changes
