### PR TITLE
chore: bump codecov-action to 5.0.3

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -66,7 +66,7 @@ jobs:
         run: poetry run pytest --cov-report=xml
         shell: bash
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v5.0.3
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 


### PR DESCRIPTION
coverage reporting is missing on https://github.com/aio-libs/aiohappyeyeballs/pull/114