### PR TITLE
chore: update ubuntu CI runner to latest

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,7 +42,7 @@ jobs:
           - "3.12"
           - "3.13"
         os:
-          - ubuntu-20.04
+          - ubuntu-latest
           - windows-latest
           - macOS-latest
         exclude:


### PR DESCRIPTION
This was only pinned for Python 3.8
