### PR TITLE
fix: keep classifiers in project to avoid automatic enrichment

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,15 +5,7 @@ description = "Happy Eyeballs for asyncio"
 authors = [{ name = "J. Nick Koston", email = "nick@koston.org" }]
 readme = "README.md"
 requires-python = ">=3.9"
-dynamic = ["classifiers", "dependencies", "optional-dependencies"]
-
-[project.urls]
-"Repository" = "https://github.com/aio-libs/aiohappyeyeballs"
-"Documentation" = "https://aiohappyeyeballs.readthedocs.io"
-"Bug Tracker" = "https://github.com/aio-libs/aiohappyeyeballs/issues"
-"Changelog" = "https://github.com/aio-libs/aiohappyeyeballs/blob/main/CHANGELOG.md"
-
-[tool.poetry]
+dynamic = ["dependencies", "optional-dependencies"]
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
@@ -28,6 +20,14 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "License :: OSI Approved :: Python Software Foundation License"
 ]
+
+[project.urls]
+"Repository" = "https://github.com/aio-libs/aiohappyeyeballs"
+"Documentation" = "https://aiohappyeyeballs.readthedocs.io"
+"Bug Tracker" = "https://github.com/aio-libs/aiohappyeyeballs/issues"
+"Changelog" = "https://github.com/aio-libs/aiohappyeyeballs/blob/main/CHANGELOG.md"
+
+[tool.poetry]
 license = "PSF-2.0"
 packages = [
     { include = "aiohappyeyeballs", from = "src" },


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Pull request #131 was incorrectly merged with #132. This causes `classifiers` to end up in `[tool.poetry]` again.
This is against what we want, since we don't want to do automatic classifiers enrichment. Behavior is documented in [Poetry docs](https://python-poetry.org/docs/pyproject/#classifiers)

Metadata with this patch looks like this
```
Metadata-Version: 2.3
Name: aiohappyeyeballs
Version: 2.4.4
Summary: Happy Eyeballs for asyncio
License: PSF-2.0
Author: J. Nick Koston
Author-email: nick@koston.org
Requires-Python: >=3.9
Classifier: Development Status :: 5 - Production/Stable
Classifier: Intended Audience :: Developers
Classifier: Natural Language :: English
Classifier: Operating System :: OS Independent
Classifier: Topic :: Software Development :: Libraries
Classifier: Programming Language :: Python :: 3
Classifier: Programming Language :: Python :: 3.9
Classifier: Programming Language :: Python :: 3.10
Classifier: Programming Language :: Python :: 3.11
Classifier: Programming Language :: Python :: 3.12
Classifier: Programming Language :: Python :: 3.13
Classifier: License :: OSI Approved :: Python Software Foundation License
Project-URL: Bug Tracker, https://github.com/aio-libs/aiohappyeyeballs/issues
Project-URL: Changelog, https://github.com/aio-libs/aiohappyeyeballs/blob/main/CHANGELOG.md
Project-URL: Documentation, https://aiohappyeyeballs.readthedocs.io
Project-URL: Repository, https://github.com/aio-libs/aiohappyeyeballs
Description-Content-Type: text/markdown
```

## Are there changes in behavior for the user?

N/A

## Related issue number
Part of #130

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
