### PR TITLE
fix: resolve warnings when running tests

### DIFF
--- a/src/aiohappyeyeballs/_staggered.py
+++ b/src/aiohappyeyeballs/_staggered.py
@@ -16,6 +16,8 @@ from typing import (
 
 _T = TypeVar("_T")
 
+RE_RAISE_EXCEPTIONS = (SystemExit, KeyboardInterrupt)
+
 
 def _set_result(wait_next: "asyncio.Future[None]") -> None:
     """Set the result of a future if it is not already done."""
@@ -125,7 +127,7 @@ async def staggered_race(
         """
         try:
             result = await coro_fn()
-        except (SystemExit, KeyboardInterrupt):
+        except RE_RAISE_EXCEPTIONS:
             raise
         except BaseException as e:
             exceptions[this_index] = e

--- a/tests/test_impl.py
+++ b/tests/test_impl.py
@@ -6,7 +6,7 @@ from unittest import mock
 
 import pytest
 
-from aiohappyeyeballs import start_connection
+from aiohappyeyeballs import _staggered, start_connection
 
 
 def mock_socket_module():
@@ -1652,11 +1652,14 @@ async def test_uvloop_mixing_os_and_runtime_error(
 
 @patch_socket
 @pytest.mark.asyncio
-@pytest.mark.xfail(reason="raises RuntimeError: coroutine ignored GeneratorExit")
 async def test_handling_system_exit(
     m_socket: ModuleType,
 ) -> None:
     """Test handling SystemExit."""
+
+    class MockSystemExit(BaseException):
+        """Mock SystemExit."""
+
     mock_socket = mock.MagicMock(
         family=socket.AF_INET,
         type=socket.SOCK_STREAM,
@@ -1674,7 +1677,7 @@ async def test_handling_system_exit(
         sock: socket.socket, address: Tuple[str, int, int, int]
     ) -> None:
         create_calls.append(address)
-        raise SystemExit
+        raise MockSystemExit
 
     m_socket.socket = _socket  # type: ignore
     ipv6_addr_info = (
@@ -1716,9 +1719,9 @@ async def test_handling_system_exit(
         ),
     ]
     loop = asyncio.get_running_loop()
-    with pytest.raises(SystemExit), mock.patch.object(
+    with pytest.raises(MockSystemExit), mock.patch.object(
         loop, "sock_connect", _sock_connect
-    ):
+    ), mock.patch.object(_staggered, "RE_RAISE_EXCEPTIONS", (MockSystemExit,)):
         await start_connection(
             addr_info,
             happy_eyeballs_delay=0.3,

--- a/tests/test_staggered.py
+++ b/tests/test_staggered.py
@@ -84,3 +84,4 @@ def test_multiple_winners_eager_task_factory():
         assert excs == [None, None, None, None]
 
     loop.run_until_complete(run())
+    loop.close()


### PR DESCRIPTION

<!-- Thank you for your contribution! -->

## What do these changes do?

- Instead of raising SystemExit which causes a RuntimeError, mock out SystemExit to a new exception
- Make sure the event loop is closed in tests



## Are there changes in behavior for the user?

no

## Related issue number
fixes #97
