### PR TITLE
feat: add callback for users to customize socket creation

### DIFF
--- a/src/aiohappyeyeballs/__init__.py
+++ b/src/aiohappyeyeballs/__init__.py
@@ -1,11 +1,12 @@
 __version__ = "2.4.8"
 
 from .impl import start_connection
-from .types import AddrInfoType
+from .types import AddrInfoType, SocketFactoryType
 from .utils import addr_to_addr_infos, pop_addr_infos_interleave, remove_addr_infos
 
 __all__ = (
     "AddrInfoType",
+    "SocketFactoryType",
     "addr_to_addr_infos",
     "pop_addr_infos_interleave",
     "remove_addr_infos",

--- a/src/aiohappyeyeballs/types.py
+++ b/src/aiohappyeyeballs/types.py
@@ -1,6 +1,7 @@
 """Types for aiohappyeyeballs."""
 
 import socket
+from collections.abc import Callable
 from typing import Tuple, Union
 
 AddrInfoType = Tuple[
@@ -10,3 +11,5 @@ AddrInfoType = Tuple[
     str,
     Tuple,  # type: ignore[type-arg]
 ]
+
+SocketFactoryType = Callable[[AddrInfoType], socket.socket]


### PR DESCRIPTION
## What do these changes do?
Adds optional parameter for a socket factory function. This is used for socket creation in place of socket.socket(). Allows setting socket options prior to connection establishment.

My personal use case is to set ToS and traffic class of IPv4 and IPv6 packets respectively.

## Are there changes in behavior for the user?
This feature is optional. No change for existing use cases.

## Related issue number
Fixes #146

## Checklist
- [X] I think the code is well written
- [X] Unit tests for the changes exist
- [ ] Documentation reflects the changes
