### PR TITLE
feat(docs): publish documentation

### DIFF
--- a/docs/api_reference.rst
+++ b/docs/api_reference.rst
@@ -1,0 +1,45 @@
+API Reference
+=============
+
+.. autodata:: aiohappyeyeballs.AddrInfoType
+
+   A tuple representing socket address information.
+
+   Indexes:
+
+   **[0]** ``Union[int, socket.AddressFamily]``
+
+      The address family, e.g. ``socket.AF_INET``
+
+   **[1]** ``Union[int, socket.SocketKind]``
+
+      The type of socket, e.g. ``socket.SOCK_STREAM``.
+
+   **[2]** ``int``
+
+      The protocol number, e.g. ``socket.IPPROTO_TCP``.
+
+   **[3]** ``str``
+
+      The canonical name of the address, e.g. ``"www.example.com"``.
+
+   **[4]** ``Tuple``
+
+      The socket address tuple, e.g. ``("127.0.0.1", 443)``.
+
+.. autodata:: aiohappyeyeballs.SocketFactoryType
+
+   A callable that creates a socket from an ``AddrInfoType``.
+
+
+   :param AddrInfoType: Address info for creating the socket containing
+      the address family, socket type, protocol, host address, and
+      additional details.
+
+   :rtype: ``socket.socket``
+
+
+.. automodule:: aiohappyeyeballs
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,7 @@ release = "2.5.0"
 # General configuration
 extensions = [
     "myst_parser",
+    "sphinx.ext.autodoc",
 ]
 
 # The suffix of source filenames.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,6 +4,7 @@
 :caption: Installation & Usage
 :maxdepth: 2
 
+api_reference
 installation
 usage
 ```


### PR DESCRIPTION
Creates an api_reference.rst file to expose the existing documentation for the few functions that have docstrings, as well as add documentation for AddrInfoType and SocketFactoryType. Now, these can be properly pointed to by other projects' documentation.

<!-- Thank you for your contribution! -->

## What do these changes do?

Publish documentation so it can be pointed to by other projects.

<!-- Please give a short brief about these changes. -->

## Are there changes in behavior for the user?

No.

<!-- Outline any notable behaviour for the end users. -->

## Related issue number

N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
