### PR TITLE
fix: resolve TypeError on import for Python < 3.9.2

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,6 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
+          - "3.9.1" # https://github.com/aio-libs/aiohappyeyeballs/issues/150
           - "3.9"
           - "3.10"
           - "3.11"

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -36,7 +36,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.9.1" # https://github.com/aio-libs/aiohappyeyeballs/issues/150
           - "3.9"
           - "3.10"
           - "3.11"
@@ -49,6 +48,9 @@ jobs:
         exclude:
           - os: macOS-latest
             python-version: "3.8.0"
+        include:
+          - os: ubuntu-20.04
+            python-version: "3.9.1" # https://github.com/aio-libs/aiohappyeyeballs/issues/150
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,7 +48,7 @@ jobs:
         include:
           # https://github.com/aio-libs/aiohappyeyeballs/issues/150
           - os: ubuntu-20.04
-            python-version: "3.9.1" 
+            python-version: "3.9.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/src/aiohappyeyeballs/_staggered.py
+++ b/src/aiohappyeyeballs/_staggered.py
@@ -1,5 +1,8 @@
 import asyncio
 import contextlib
+
+# PY3.9: Import Callable from typing until we drop Python 3.9 support
+# https://github.com/python/cpython/issues/87131
 from typing import (
     TYPE_CHECKING,
     Any,

--- a/src/aiohappyeyeballs/types.py
+++ b/src/aiohappyeyeballs/types.py
@@ -1,8 +1,10 @@
 """Types for aiohappyeyeballs."""
 
 import socket
-from collections.abc import Callable
-from typing import Tuple, Union
+
+# PY3.9: Import Callable from typing until we drop Python 3.9 support
+# https://github.com/python/cpython/issues/87131
+from typing import Callable, Tuple, Union
 
 AddrInfoType = Tuple[
     Union[int, socket.AddressFamily],

--- a/tests/test_staggered.py
+++ b/tests/test_staggered.py
@@ -1,10 +1,12 @@
 import asyncio
 import sys
+from collections.abc import Callable as CallableABC
 from functools import partial
+from typing import Callable as CallableTyping
 
 import pytest
 
-from aiohappyeyeballs._staggered import staggered_race
+from aiohappyeyeballs._staggered import Callable, staggered_race
 
 
 @pytest.mark.asyncio
@@ -85,3 +87,13 @@ def test_multiple_winners_eager_task_factory():
 
     loop.run_until_complete(run())
     loop.close()
+
+
+def test_callable_import_from_typing():
+    """
+    Test that Callable is imported from typing.
+
+    PY3.9: https://github.com/python/cpython/issues/87131
+    """
+    assert Callable is CallableTyping
+    assert Callable is not CallableABC

--- a/tests/test_staggered.py
+++ b/tests/test_staggered.py
@@ -94,6 +94,8 @@ def test_callable_import_from_typing():
     Test that Callable is imported from typing.
 
     PY3.9: https://github.com/python/cpython/issues/87131
+
+    Drop this test when we drop support for Python 3.9.
     """
     assert Callable is CallableTyping
     assert Callable is not CallableABC

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,14 @@
+from collections.abc import Callable as CallableABC
+from typing import Callable as CallableTyping
+
+from aiohappyeyeballs.types import Callable
+
+
+def test_callable_import_from_typing():
+    """
+    Test that Callable is imported from typing.
+
+    PY3.9: https://github.com/python/cpython/issues/87131
+    """
+    assert Callable is CallableTyping
+    assert Callable is not CallableABC


### PR DESCRIPTION
https://github.com/aio-libs/aiohappyeyeballs/issues/150 shows we have a problem with Python < 3.9.2

This is because of a bug in cpython that was not fixed until 3.9.2 https://github.com/python/cpython/issues/87131

fixes #150