### PR TITLE
chore: remove unused CI exclude for Python 3.8.0

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,9 +45,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        exclude:
-          - os: macOS-latest
-            python-version: "3.8.0"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION


<!-- Thank you for your contribution! -->

## What do these changes do?

Removes an exclude line in the CI for Python 3.8.0


This should have been removed when we dropped Python 3.8 support