### PR TITLE
chore: drop Python 3.9.1 CI runner

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -47,7 +47,7 @@ jobs:
           - macOS-latest
         include:
           # https://github.com/aio-libs/aiohappyeyeballs/issues/150
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             python-version: "3.9.1"
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -45,10 +45,6 @@ jobs:
           - ubuntu-latest
           - windows-latest
           - macOS-latest
-        include:
-          # https://github.com/aio-libs/aiohappyeyeballs/issues/150
-          - os: ubuntu-22.04
-            python-version: "3.9.1"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
3.9.1 images are no longer available.

I don't think we will regress #150 before 2025-10 so this is low risk to drop
