### PR TITLE
optimize obtaining event-loop down to 1 line

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -51,8 +51,8 @@ async def start_connection(
             transport, protocol = await loop.create_connection(
                 MyProtocol, sock=socket, ...)
     """
-    if not (current_loop := loop):
-        current_loop = asyncio.get_running_loop()
+    
+    current_loop = loop or asyncio.get_running_loop()
 
     single_addr_info = len(addr_infos) == 1
 


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Very tiny change that optimizes the first line of start_connection that says if the eventloop provided is None use asyncio.get_running_loop
## Are there changes in behavior for the user?

This is internal refactoring and shouldn't affect the frontend of this library.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
<!-- Remember to prefix with 'Fixes' if it should close the issue (e.g. 'Fixes #123'). -->

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
