### PR TITLE
ci: switch runner setup to astral uv

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -48,12 +48,18 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install Poetry
+        run: uv tool install poetry
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: "poetry"
           allow-prereleases: true
-      - uses: snok/install-poetry@v1.4.1
       - name: Install Dependencies
         run: poetry install
         shell: bash
@@ -88,7 +94,12 @@ jobs:
         with:
           root_options: --noop
 
-      - uses: snok/install-poetry@v1.4.1
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
+      - name: Install Poetry
+        run: uv tool install poetry
       - name: Install Dependencies
         run: poetry install --only main,test_build
         shell: bash


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Bootstrap Poetry via `astral-sh/setup-uv` plus `uv tool install poetry` in the `test` and `test_release` jobs, replacing `snok/install-poetry`; uv handles its own cache and `setup-python` caches the Poetry venv.

## Are there changes in behavior for the user?

No, only CI runner provisioning changes; Poetry stays the build backend and the install, test, and build commands are unchanged.

## Related issue number

Closes #212

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes