### PR TITLE
ci: use no_operation_mode for psr v10 dry-run step

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Test release
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          root_options: --noop
+          no_operation_mode: true
 
       - name: Set up uv
         uses: astral-sh/setup-uv@v8.1.0


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The `test_release` job pins `python-semantic-release@v10.5.3`, but v10 dropped the `root_options` input; the workflow's `root_options: --noop` is silently ignored (the action logs an "Unexpected input(s) 'root_options'" warning), so the dry-run step actually tries to release and push, which 403s on Dependabot PRs because `GITHUB_TOKEN` is read-only. Switch to the renamed `no_operation_mode: true` input.

See the failing run on #198: https://github.com/aio-libs/aiohappyeyeballs/actions/runs/26171611215/job/76990813105?pr=198

## Are there changes in behavior for the user?

No, CI-only change.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes