### PR TITLE
refactor: simplify _interleave_addrinfos family grouping

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -1,7 +1,6 @@
 """Base implementation."""
 
 import asyncio
-import collections
 import contextlib
 import functools
 import itertools
@@ -239,14 +238,9 @@ def _interleave_addrinfos(
 ) -> list[AddrInfoType]:
     """Interleave list of addrinfo tuples by family."""
     # Group addresses by family
-    addrinfos_by_family: collections.OrderedDict[int, list[AddrInfoType]] = (
-        collections.OrderedDict()
-    )
+    addrinfos_by_family: dict[int, list[AddrInfoType]] = {}
     for addr in addrinfos:
-        family = addr[0]
-        if family not in addrinfos_by_family:
-            addrinfos_by_family[family] = []
-        addrinfos_by_family[family].append(addr)
+        addrinfos_by_family.setdefault(addr[0], []).append(addr)
     addrinfos_lists = list(addrinfos_by_family.values())
 
     reordered: list[AddrInfoType] = []

--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -240,7 +240,11 @@ def _interleave_addrinfos(
     # Group addresses by family
     addrinfos_by_family: dict[int, list[AddrInfoType]] = {}
     for addr in addrinfos:
-        addrinfos_by_family.setdefault(addr[0], []).append(addr)
+        family = addr[0]
+        try:
+            addrinfos_by_family[family].append(addr)
+        except KeyError:
+            addrinfos_by_family[family] = [addr]
     addrinfos_lists = list(addrinfos_by_family.values())
 
     reordered: list[AddrInfoType] = []


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`dict` has preserved insertion order since Python 3.7 and the project requires 3.10+, so `collections.OrderedDict` here is just noise. Swap it for a plain `dict`, group with a `try/except KeyError` append so we only allocate the per-family list when the family is first seen (avoids the eager `[]` allocation that `setdefault(family, [])` would do every iteration), and drop the now-unused `collections` import.

## Are there changes in behavior for the user?

No, pure simplification; grouping order and resulting interleave are unchanged.

## Related issue number

Closes #208

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes