### PR TITLE
refactor: collapse collect-then-remove pattern in utils helpers

### DIFF
--- a/src/aiohappyeyeballs/utils.py
+++ b/src/aiohappyeyeballs/utils.py
@@ -40,19 +40,17 @@ def pop_addr_infos_interleave(
     The interleave parameter is used to know how many addr_infos for
     each family should be popped of the top of the list.
     """
-    seen: dict[int, int] = {}
     if interleave is None:
         interleave = 1
-    to_remove: list[AddrInfoType] = []
+    seen: dict[int, int] = {}
+    kept: list[AddrInfoType] = []
     for addr_info in addr_infos:
         family = addr_info[0]
-        if family not in seen:
-            seen[family] = 0
-        if seen[family] < interleave:
-            to_remove.append(addr_info)
-        seen[family] += 1
-    for addr_info in to_remove:
-        addr_infos.remove(addr_info)
+        count = seen.get(family, 0)
+        if count >= interleave:
+            kept.append(addr_info)
+        seen[family] = count + 1
+    addr_infos[:] = kept
 
 
 def _addr_tuple_to_ip_address(
@@ -72,21 +70,13 @@ def remove_addr_infos(
     The addr value is typically the return value of
     sock.getpeername().
     """
-    bad_addrs_infos: list[AddrInfoType] = []
-    for addr_info in addr_infos:
-        if addr_info[-1] == addr:
-            bad_addrs_infos.append(addr_info)
-    if bad_addrs_infos:
-        for bad_addr_info in bad_addrs_infos:
-            addr_infos.remove(bad_addr_info)
-        return
-    # Slow path in case addr is formatted differently
-    match_addr = _addr_tuple_to_ip_address(addr)
-    for addr_info in addr_infos:
-        if match_addr == _addr_tuple_to_ip_address(addr_info[-1]):
-            bad_addrs_infos.append(addr_info)
-    if bad_addrs_infos:
-        for bad_addr_info in bad_addrs_infos:
-            addr_infos.remove(bad_addr_info)
-        return
-    raise ValueError(f"Address {addr} not found in addr_infos")
+    bad_addrs_infos = [ai for ai in addr_infos if ai[-1] == addr]
+    if not bad_addrs_infos:
+        # Slow path in case addr is formatted differently
+        match_addr = _addr_tuple_to_ip_address(addr)
+        bad_addrs_infos = [
+            ai for ai in addr_infos if _addr_tuple_to_ip_address(ai[-1]) == match_addr
+        ]
+    if not bad_addrs_infos:
+        raise ValueError(f"Address {addr} not found in addr_infos")
+    addr_infos[:] = [ai for ai in addr_infos if ai not in bad_addrs_infos]

--- a/src/aiohappyeyeballs/utils.py
+++ b/src/aiohappyeyeballs/utils.py
@@ -70,13 +70,13 @@ def remove_addr_infos(
     The addr value is typically the return value of
     sock.getpeername().
     """
-    bad_addrs_infos = [ai for ai in addr_infos if ai[-1] == addr]
-    if not bad_addrs_infos:
+    kept = [ai for ai in addr_infos if ai[-1] != addr]
+    if len(kept) == len(addr_infos):
         # Slow path in case addr is formatted differently
         match_addr = _addr_tuple_to_ip_address(addr)
-        bad_addrs_infos = [
-            ai for ai in addr_infos if _addr_tuple_to_ip_address(ai[-1]) == match_addr
+        kept = [
+            ai for ai in addr_infos if _addr_tuple_to_ip_address(ai[-1]) != match_addr
         ]
-    if not bad_addrs_infos:
+    if len(kept) == len(addr_infos):
         raise ValueError(f"Address {addr} not found in addr_infos")
-    addr_infos[:] = [ai for ai in addr_infos if ai not in bad_addrs_infos]
+    addr_infos[:] = kept

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -47,6 +47,32 @@ def test_pop_addr_infos_interleave():
     assert addr_info_copy == [ipv6_addr_info_2]
 
 
+def test_pop_addr_infos_interleave_with_duplicates():
+    """Duplicate entries past the interleave window must be kept."""
+    ipv6_addr_info = (
+        socket.AF_INET6,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("dead:beef::", 80, 0, 0),
+    )
+    ipv4_addr_info = (
+        socket.AF_INET,
+        socket.SOCK_STREAM,
+        socket.IPPROTO_TCP,
+        "",
+        ("107.6.106.83", 80),
+    )
+    addr_info: list[AddrInfoType] = [
+        ipv6_addr_info,
+        ipv6_addr_info,
+        ipv4_addr_info,
+        ipv4_addr_info,
+    ]
+    pop_addr_infos_interleave(addr_info, 1)
+    assert addr_info == [ipv6_addr_info, ipv4_addr_info]
+
+
 def test_remove_addr_infos():
     """Test remove_addr_infos."""
     ipv6_addr_info = (


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

Both `pop_addr_infos_interleave` and `remove_addr_infos` were building a list of matches and then calling `list.remove()` once per match, which is O(n*m) and removes by value; `remove_addr_infos` also wrote out the removal block twice, once for the fast path and once for the slow path. Replace each with a single slice-assignment rebuild. `pop_addr_infos_interleave` keeps exact semantics for duplicate entries by appending to a `kept` list in the same pass that tracks per-family counts.

## Are there changes in behavior for the user?

No, the observable behavior is unchanged for non-duplicate addr_infos (the only case `getaddrinfo` produces), and the duplicate-handling semantics of `pop_addr_infos_interleave` are preserved by the kept-list approach.

## Related issue number

Closes #209

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes