### PR TITLE
refactor: merge identical except blocks in _connect_sock cleanup

### DIFF
--- a/src/aiohappyeyeballs/impl.py
+++ b/src/aiohappyeyeballs/impl.py
@@ -209,18 +209,9 @@ async def _connect_sock(
                     raise OSError(f"no matching local address with {family=} found")
         await loop.sock_connect(sock, address)
         return sock
-    except (RuntimeError, OSError) as exc:
-        my_exceptions.append(exc)
-        if sock is not None:
-            if open_sockets is not None:
-                open_sockets.remove(sock)
-            try:
-                sock.close()
-            except OSError as e:
-                my_exceptions.append(e)
-                raise
-        raise
-    except:
+    except BaseException as exc:
+        if isinstance(exc, (RuntimeError, OSError)):
+            my_exceptions.append(exc)
         if sock is not None:
             if open_sockets is not None:
                 open_sockets.remove(sock)


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

`_connect_sock` had two `except` blocks whose bodies were byte-for-byte identical except for one line; the only real difference is whether the exception is recorded in `my_exceptions`. Collapse them into a single `except BaseException as exc:` with an `isinstance((RuntimeError, OSError))` guard around the append, so the 8-line socket teardown lives in one place.

## Are there changes in behavior for the user?

No, the merged handler preserves exact semantics; `RuntimeError`/`OSError` still land in `my_exceptions`, everything else (including `CancelledError`, `SystemExit`) still runs cleanup and re-raises without being recorded. The existing `test_handling_system_exit`, `test_cancellation_is_not_swallowed`, and `test_single_addr_info_close_errors` cover both branches and stay green.

## Related issue number

Closes #206.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes
