### PR TITLE
ci: scope release concurrency group per ref

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -88,7 +88,9 @@ jobs:
 
     runs-on: ubuntu-latest
     environment: test_release
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     if: github.ref_name != 'main'
 
     steps:
@@ -130,7 +132,9 @@ jobs:
     outputs:
       released: ${{ steps.release.outputs.released }}
 
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write
@@ -162,7 +166,9 @@ jobs:
     if: needs.build_release.outputs.released == 'true'
     runs-on: ubuntu-latest
     environment: pypi
-    concurrency: release
+    concurrency:
+      group: release-${{ github.head_ref || github.ref }}
+      cancel-in-progress: false
     permissions:
       id-token: write
       contents: write


### PR DESCRIPTION
<!-- Thank you for your contribution! -->

## What do these changes do?

The `test_release`, `build_release`, and `release` jobs all use `concurrency: release`, which is a single global group across every branch and PR; as soon as another run with the same group lands, the queued one gets bumped, which is what cancelled `test_release` on #198. Scope the group per ref (`release-${{ github.head_ref || github.ref }}`) so PR dry-runs run independently while main still serializes on `release-refs/heads/main`. `cancel-in-progress: false` keeps queued jobs from killing each other; the workflow-level concurrency already cancels stale runs per head_ref.

## Are there changes in behavior for the user?

No, CI-only change.

## Related issue number

None.

## Checklist

- [x] I think the code is well written
- [x] Unit tests for the changes exist
- [x] Documentation reflects the changes